### PR TITLE
[pdnsrec] Expose web UI port

### DIFF
--- a/pdnsrec/Dockerfile
+++ b/pdnsrec/Dockerfile
@@ -72,7 +72,9 @@ ENV TZ Asia/Tokyo
 # service running
 STOPSIGNAL SIGTERM
 
-# export DNS over UDP
+# expose webserver port
+EXPOSE 8082
+# expose DNS over UDP/TCP
 EXPOSE 53/UDP 
 EXPOSE 53/TCP
 


### PR DESCRIPTION
Port 8082 is the default webserver port. Exposing it will make it easy for apps that use service discovery.