### PR TITLE
Update Dockerfiles for improved dependency management

### DIFF
--- a/hickory-dns/Dockerfile
+++ b/hickory-dns/Dockerfile
@@ -31,7 +31,7 @@ RUN \
 
 # Install build dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y ${BUILD_BASE} ${BUILD_PKGS} \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y ${BUILD_PKGS} \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo fetch
@@ -75,7 +75,8 @@ LABEL org.label-schema.vendor="hickory-dns" \
 
 # https://github.com/mischov/meeseeks/issues/98#issuecomment-636615680
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libssl3 \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libssl3 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r nobody
 

--- a/kea/Dockerfile
+++ b/kea/Dockerfile
@@ -16,9 +16,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
     && apt-get install -y ${BUILD_PKGS} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100 \
-    && update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
+    && CLANG_VER=$(ls /usr/bin/clang-[0-9]* 2>/dev/null | grep -oP 'clang-\K[0-9]+' | sort -rn | head -1) \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VER} 100 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VER} 100 \
+    && update-alternatives --install /usr/bin/lld lld /usr/bin/lld-${CLANG_VER} 100
 
 # Install modern Meson version via pip (required for Kea 3.0.0)
 RUN pip3 install --break-system-packages --no-cache-dir meson>=1.8.0 \

--- a/kresd/Dockerfile
+++ b/kresd/Dockerfile
@@ -6,9 +6,8 @@ FROM debian:stable AS build
 ARG VERSION=6.0.11
 ARG BUILD_PKGS="apt-transport-https ca-certificates wget pipx devscripts mkdocs git"
 
-# Use a specific reliable mirror
-RUN echo "deb http://ftp.jp.debian.org/debian/ trixie main" > /etc/apt/sources.list && \
-    echo "deb http://ftp.jp.debian.org/debian/ trixie-updates main" >> /etc/apt/sources.list && \
+RUN echo "deb http://deb.debian.org/debian/ trixie main" > /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian/ trixie-updates main" >> /etc/apt/sources.list && \
     echo "deb http://security.debian.org/debian-security trixie-security main" >> /etc/apt/sources.list
 
 # Install build dependencies

--- a/nsd/Dockerfile
+++ b/nsd/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 # ===== Common Build Base =====
-FROM debian:latest AS common-build-base
+FROM debian:stable AS common-build-base
 
 # Common build environment and packages
 ARG COMMON_BUILD="build-essential make gawk autoconf automake libtool curl binutils pkg-config"

--- a/stubby/Dockerfile
+++ b/stubby/Dockerfile
@@ -88,7 +88,7 @@ RUN unbound-anchor -v -a "/tmp/root/etc/unbound/getdns-root.key" || true \
 FROM debian:stable-slim AS runtime-base
 
 # Install tini and runtime dependencies
-ARG RUN_PKGS="libyaml-0-2 libuv1 libev4 libevent-2.1 tini libidn2-0 ca-certificates libp11-kit0 libssl3"
+ARG RUN_PKGS="libyaml-0-2 libuv1 libev4 libevent-2.1-7 tini libidn2-0 ca-certificates libp11-kit0 libssl3"
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
     && apt-get -y -qqq install --no-install-recommends ${RUN_PKGS} \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
## 変更内容

- ソフトウェア名: hickory-dns, kea, kresd, nsd, stubby
- 変更前バージョン: Various previous versions
- 変更後バージョン: Updated to use stable Debian version and improved dependency handling
- リリースノート: Updated Dockerfiles to install specific versions of dependencies, use a reliable Debian mirror, and clean up APT cache.

## ビルド確認

- [x] ローカル ビルド成功
- [x] 動作確認済み

## 備考

<!-- 特記事項があれば -->

