### PR TITLE
feat(coredns): runtime imageをscratchからdistroless/static-debian13に変更

### DIFF
--- a/coredns/Dockerfile
+++ b/coredns/Dockerfile
@@ -1,4 +1,5 @@
 # syntax = docker/dockerfile:1.4
+# check=error=true
 # Multi-architecture and multi-stage build for CoreDNS
 
 # Build stage with common dependencies
@@ -34,18 +35,16 @@ RUN make -j"$(nproc)" && \
     rm -rf man/ test/ doc/
 
 # Runtime stage
-FROM scratch
+FROM gcr.io/distroless/static-debian13
 
 # Environment
-ENV TZ Asia/Tokyo
+ENV TZ=Asia/Tokyo
 
 # Publish ports for DNS over UDP & TCP
 EXPOSE 53/TCP 53/UDP 443/TCP 443/UDP
 
-# Copy CA certificates and the CoreDNS binary
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Copy the CoreDNS binary
 COPY --from=builder /go/src/github.com/coredns/coredns/coredns /coredns
-COPY --from=builder /usr/share/zoneinfo/ /usr/share/zoneinfo/
 
 # Set entrypoint
 ENTRYPOINT ["/coredns"]

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -1,0 +1,51 @@
+# CoreDNS
+
+CoreDNS <https://coredns.io/>
+
+## description
+
+[![](https://images.microbadger.com/badges/image/kometchtech/coredns:20181112.svg)](https://microbadger.com/images/kometchtech/coredns:20181112 "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/kometchtech/coredns:20181112.svg)](https://microbadger.com/images/kometchtech/coredns:20181112 "Get your own version badge on microbadger.com")
+[![Docker Pulls](https://img.shields.io/docker/pulls/kometchtech/coredns.svg)](https://hub.docker.com/r/kometchtech/coredns/)
+
+## !Announce!
+
+As the Arm64 image is released from the official, it will not be updated here.
+
+- [coredns/coredns](https://hub.docker.com/r/coredns/coredns/)  
+ - tag: coredns-arm64
+
+### Baseimage
+
+- arm64v8/alpine:latest
+
+### Baseimage
+
+- `gcr.io/distroless/static-debian13`
+
+> **Note:** distroless イメージは `nonroot` ユーザー (UID 65532) で実行されます。
+> ポート 53 などの特権ポート (< 1024) にバインドするには、コンテナ起動時に
+> `CAP_NET_BIND_SERVICE` ケーパビリティの付与が必要です。
+
+### minimum operating
+
+```bash
+docker run --rm -d \
+  --cap-add=NET_BIND_SERVICE \
+  -p 53:53/tcp -p 53:53/udp \
+  -v ${PWD}:/etc/coredns/corefile \
+  kometchtech/coredns
+```
+
+### config
+
+```cady
+.:53 {
+    forward . 8.8.8.8:53
+    log
+}
+```
+
+### document page
+
+<https://coredns.io/manual/toc/>


### PR DESCRIPTION
## Summary
- `FROM scratch` → `gcr.io/distroless/static-debian13` に変更
- `ca-certificates.crt` のCOPYを削除（distrolessに同梱済み）
- `/usr/share/zoneinfo` のCOPYを削除（distrolessに同梱済み）

## 背景
CoreDNSはGo製で `CGO_ENABLED=0` による完全静的バイナリのため `distroless/static` が適切。
distrolessはca-certificatesとtzdataを同梱しており、手動コピーが不要になる。
またCVEスキャンの精度向上やnonrootユーザーによる実行が可能になる。

## Test plan
- [ ] `docker build` が正常完了すること
- [ ] コンテナ起動後、DNS解決が正常に動作すること
- [ ] `TZ=Asia/Tokyo` が正しく反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)