### PR TITLE
feat(dnscrypt-proxy): runtime imageをscratchからdistroless/static-debian13に変更

### DIFF
--- a/dnscrypt-proxy/Dockerfile
+++ b/dnscrypt-proxy/Dockerfile
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
              -o /go/bin/dnscrypt-proxy
 
 # Final stage
-FROM scratch
+FROM gcr.io/distroless/static-debian13
 
 # Environment variables
 ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
@@ -33,11 +33,9 @@ ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 # Expose DNS ports
 EXPOSE 53/TCP 53/UDP
 
-# Copy SSL certificates and binary from builder
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Copy binary and config files from builder
 COPY --from=builder /go/bin/dnscrypt-proxy /
 COPY --from=builder /src/dnscrypt-proxy/example-* /etc/dnscrypt-proxy/
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # Set working directory
 WORKDIR /etc/dnscrypt-proxy/


### PR DESCRIPTION
## Summary
- `FROM scratch` → `gcr.io/distroless/static-debian13` に変更
- `ca-certificates.crt` のCOPYを削除（distrolessに同梱済み）
- `/usr/share/zoneinfo` のCOPYを削除（distrolessに同梱済み）

## 背景
dnscrypt-proxyはGo製で `CGO_ENABLED=0` + `-tags "osusergo netgo"` による完全静的バイナリのため `distroless/static` が適切。
distrolessはca-certificatesとtzdataを同梱しており、手動コピーが不要になる。
またCVEスキャンの精度向上やnonrootユーザーによる実行が可能になる。

## Test plan
- [ ] `docker build` が正常完了すること
- [ ] コンテナ起動後、DNS解決が正常に動作すること
- [ ] `TZ=Asia/Tokyo` が正しく反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)